### PR TITLE
Update simple example run instructions in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,16 @@
 ## Development
 
 ```bash
+# Build the command-line tool.
+cd packages/@keynote/cli 
 yarn
-yarn dev # serves an example presentation
+
+# Use the command-line tool to serve the simple example.
+cd bin
+./keynote.js dev ../../../../example/Simple.vue
 ```
+
+Go to http://localhost:8080 to view the example presentation.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -10,17 +10,31 @@
 
 ## Development
 
+### To run the sample presentation
+
 ```bash
 # Build the command-line tool.
 cd packages/@keynote/cli 
 yarn
 
-# Use the command-line tool to serve the simple example.
+# Use the command-line tool to serve the sample presentation.
 cd bin
 ./keynote.js dev ../../../../example/Simple.vue
 ```
 
-Go to http://localhost:8080 to view the example presentation.
+Visit http://localhost:8080 in a browser to view the sample presentation.
+
+### To build the site (https://keynote.sh/)
+
+```bash
+# Install VuePress.
+yarn global add vuepress
+
+# Build the site.
+yarn docs:dev
+```
+
+Visit http://localhost:8080 in a browser to view the Keynote web site.
 
 ## License
 


### PR DESCRIPTION
The current instructions do not work (there is no ‘dev’ task in
the root package.json). I’ve added the instructions that allowed
me to run the simple example after cloning the repo.